### PR TITLE
Adding essential space to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ EXAMPLES:
 
   Override [jsdocconf.json](http://usejsdoc.org/about-configuring-jsdoc.html):
 
-    docme README.md-- --configure ./myconf.json
+    docme README.md -- --configure ./myconf.json
 
   Override loglevel and jsoc configuration:
 

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -20,7 +20,7 @@ EXAMPLES:
 
   Override [jsdocconf.json](http://usejsdoc.org/about-configuring-jsdoc.html):
 
-    docme README.md-- --configure ./myconf.json
+    docme README.md -- --configure ./myconf.json
 
   Override loglevel and jsoc configuration:
 


### PR DESCRIPTION
Without the space you get funny errors.

```
↳ docme  README.md-- --configure ./jsdocrc.json
ERR! docme Error: The readme: README.md-- was not found from /Users/todd/src/JSXHint!
ERR! docme     at /usr/local/share/npm/lib/node_modules/docme/index.js:48:8
ERR! docme     at Object.cb [as oncomplete] (fs.js:168:19)
ERR! docme  [Error: The readme: README.md-- was not found from /Users/todd/src/JSXHint!]
```
