### PR TITLE
Better Windows support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: node_js
 node_js:
   - "0.8"
   - "0.10"
+script:
+  npm run test-all

--- a/lib/run-jsdoc.js
+++ b/lib/run-jsdoc.js
@@ -14,10 +14,10 @@ var jsdocpackfile = path.join(__dirname, '..', 'node_modules', 'jsdoc', 'package
  * ### Note about jsdocargs
  *  - they shouldn't contain `--destination` option since destination is always inside htmlroot dir
  *  - if no `--configure` option is given, the default `./config/jsdocrc.json` config is passed to jsdoc
- * 
+ *
  * @name runJsdoc
  * @private
- * @function 
+ * @function
  * @param {String} projectroot root of project whose jsdoc comments are converted to html
  * @param {String} htmlroot in which the out folder with html files is created
  * @param {Array.<String>} jsdocargs extra args for jsdoc supplied via `-- --arg one --arg two ...`
@@ -26,14 +26,14 @@ var jsdocpackfile = path.join(__dirname, '..', 'node_modules', 'jsdoc', 'package
 var go = module.exports = function runJsdoc(projectroot, htmlroot, jsdocargs, cb) {
   var out = path.join(htmlroot, 'out')
 
-  var args = [ projectroot, '--destination', out  ].concat(jsdocargs);
+  var args = [ jsdoc, projectroot, '--destination', out  ].concat(jsdocargs);
 
   if (!~jsdocargs.indexOf('--configure') && !~jsdocargs.indexOf('-c')) {
     var config = path.join(__dirname, '..', 'config', 'jsdocrc.json')
     args = args.concat([ '--configure', config ]);
-  } 
+  }
 
-  run(jsdoc, args, projectroot, function (err) {
+  run(process.execPath, args, projectroot, function (err) {
     cb(err, out);
   });
 };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test-0.8": "nave use 0.8 npm run test-main",
     "test-0.10": "nave use 0.10 npm run test-main",
     "test-all": "npm run test-main && npm run test-0.8 && npm run test-0.10",
-    "test": "if [ -e $TRAVIS ]; then npm run test-all; else git checkout master && npm run test-main; fi"
+    "test": "tap test/*.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Still some test failures because there's some path manipulation logic that causes the full filename to show up, but I can't be bothered to fix those because they're probably hidden deep inside some part of this package's massive dependency graph. (I didn't see any path-manipulation code in docme itself.)
